### PR TITLE
Fix/vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.2</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.4</version>
+            <version>2.8.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>

--- a/src/test/java/io/mikael/countries/CountriesTest.java
+++ b/src/test/java/io/mikael/countries/CountriesTest.java
@@ -7,6 +7,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import spark.Service;
 import spark.Spark;
 
 import static com.jayway.restassured.RestAssured.when;
@@ -28,7 +29,7 @@ public class CountriesTest {
 
     @Before
     public void setUp() {
-        RestAssured.port = Spark.SPARK_DEFAULT_PORT;
+        RestAssured.port = Service.SPARK_DEFAULT_PORT;
     }
 
     @Test


### PR DESCRIPTION
Fixes these issues reported by the `dependency-check-maven` plugin (and GitHub vulnerabilite alerts):
```
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
[ERROR] 
[ERROR] javax.servlet-3.0.0.v201112011016.jar: CVE-2017-7658, CVE-2017-7657
[ERROR] jetty-xml-9.0.2.v20130417.jar: CVE-2017-7658, CVE-2017-7657
[ERROR] jackson-databind-2.5.4.jar: CVE-2017-15095, CVE-2017-17485, CVE-2017-7525, CVE-2018-7489
```
