### PR TITLE
Upgrade jackson-databind 2.8.11.2 > 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.2</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
* fixes multiple vulnerabilities in jackson-databind-2.8.11.2.jar: CVE-2018-14719, CVE-2018-19362, CVE-2018-19361, CVE-2018-19360, CVE-2018-14721, CVE-2018-14720